### PR TITLE
all: convert to a Go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/chromedp/examples
+
+go 1.11
+
+require (
+	github.com/chromedp/cdproto v0.0.0-20181118001904-26b5fa12673f
+	github.com/chromedp/chromedp v0.1.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/chromedp/cdproto v0.0.0-20180713053126-e314dc107013/go.mod h1:C2GPAraqdt1KfZU7aSmx1XUgarNq/3JmxevQkmCjOVs=
+github.com/chromedp/cdproto v0.0.0-20181118001904-26b5fa12673f h1:yof7/Z1m/MHUjT6mjr2Z4PM5G0XXNEvnBFIUQBDmuXw=
+github.com/chromedp/cdproto v0.0.0-20181118001904-26b5fa12673f/go.mod h1:NcHZYATbiYX27TBzC98mmdw6oG1CGTiRXN+qGlkIzXs=
+github.com/chromedp/chromedp v0.1.2 h1:qB/dpbbbOPGkKyZU2gKB49jp+ZvY9C3rPUfYELLz+6g=
+github.com/chromedp/chromedp v0.1.2/go.mod h1:83UDY5CKmHrvKLQ6vVU+LVFUcfjOSPNufx8XFWLUYlQ=
+github.com/disintegration/imaging v1.4.2 h1:BSVxoYQ2NfLdvIGCDD8GHgBV5K0FCEsc0d/6FxQII3I=
+github.com/disintegration/imaging v1.4.2/go.mod h1:9B/deIUIrliYkyMTuXJd6OUFLcrZ2tf+3Qlwnaf/CjU=
+github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
+github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/knq/sysutil v0.0.0-20180306023629-0218e141a794 h1:hgWKTlyruPI7k8W+0FmTMLf+8d2KPxyzTxsfDDQhNp8=
+github.com/knq/sysutil v0.0.0-20180306023629-0218e141a794/go.mod h1:BjPj+aVjl9FW/cCGiF3nGh5v+9Gd3VCgBQbod/GlMaQ=
+github.com/mailru/easyjson v0.0.0-20180606163543-3fdea8d05856/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=
+github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81 h1:00VmoueYNlNz/aHIilyyQz/MHSqGoWJzpFv/HW8xpzI=
+golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=


### PR DESCRIPTION
This way, one can run the examples by just cloning the repo and using
'go build' and 'go run', without bothering with GOPATH.