### PR TITLE
Add an example for how to use chromedp.NewRemoteAllocator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following examples are currently available:
 | [headers](/headers)       | set a HTTP header on requests                                              |
 | [keys](/keys)             | send key events to an element                                              |
 | [logic](/logic)           | more complex logic beyond simple actions                                   |
+| [remote](/remote)         | connect to an existing chromium instance using chromedp.NewRemoteAllocator |
 | [screenshot](/screenshot) | take a screenshot of a specific element and of the entire browser viewport |
 | [submit](/submit)         | fill out and submit a form                                                 |
 | [text](/text)             | extract text from a specific element                                       |

--- a/remote/main.go
+++ b/remote/main.go
@@ -1,0 +1,33 @@
+// Command remote demonstrating how to connect to an existing chromium instance using chromedp.NewRemoteAllocator
+package main
+
+import (
+	"context"
+	"flag"
+	"github.com/chromedp/chromedp"
+	"log"
+)
+
+func main() {
+	var devToolWsUrl string
+	flag.StringVar(&devToolWsUrl, "devtools-ws-url", "", "DevTools Websocket URL")
+	flag.Parse()
+
+	actxt, cancelActxt := chromedp.NewRemoteAllocator(context.Background(), devToolWsUrl)
+	defer cancelActxt()
+
+	ctxt, cancelCtxt := chromedp.NewContext(actxt) // create new tab
+	defer cancelCtxt()                             // close tab afterwards
+
+	var body string
+	if err := chromedp.Run(ctxt,
+		chromedp.Navigate("https://duckduckgo.com"),
+		chromedp.WaitVisible("#logo_homepage_link"),
+		chromedp.OuterHTML("html", &body),
+	); err != nil {
+		log.Fatalf("Failed getting body of duckduckgo.com: %v", err)
+	}
+
+	log.Println("Body of duckduckgo.com starts with:")
+	log.Println(body[0:100])
+}


### PR DESCRIPTION
From the godocs of `chromedp.NewRemoteAllocator` I was not able to work out how it is supposed to be used. I ended up doing it like this. If this is how it is supposed to be used, it might make a good addition for the examples repo.