### PR TITLE
Change acronyms to upper case

### DIFF
--- a/remote/main.go
+++ b/remote/main.go
@@ -10,16 +10,16 @@ import (
 	"github.com/chromedp/chromedp"
 )
 
-var flagDevToolWsUrl = flag.String("devtools-ws-url", "", "DevTools WebSsocket URL")
+var flagDevToolWsURL = flag.String("devtools-ws-url", "", "DevTools WebSsocket URL")
 
 func main() {
 	flag.Parse()
-	if *flagDevToolWsUrl == "" {
+	if *flagDevToolWsURL == "" {
 		log.Fatal("must specify -devtools-ws-url")
 	}
 
 	// create allocator context for use with creating a browser context later
-	allocatorContext, cancel := chromedp.NewRemoteAllocator(context.Background(), *flagDevToolWsUrl)
+	allocatorContext, cancel := chromedp.NewRemoteAllocator(context.Background(), *flagDevToolWsURL)
 	defer cancel()
 
 	// create context


### PR DESCRIPTION
Hello, while testing this example, I noticed "golint" was complaining about flagDevToolWsUrl and the fact it was using a mixed-case version of an initialism (URL instead of Url) - that's the fix for it.