### PR TITLE
Add an example to illustate populating and traveling a subtree

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following examples are currently available:
 | [remote](/remote)         | connect to an existing Chrome DevTools instance using a remote WebSocket URL |
 | [screenshot](/screenshot) | take a screenshot of a specific element and of the entire browser viewport   |
 | [submit](/submit)         | fill out and submit a form                                                   |
+| [subtree](/subtree)       | populate and travel a subtree of a node                                      |
 | [text2](/text2)           | extract text from a specific element                                         |
 | [text](/text)             | extract text from a specific element                                         |
 | [upload](/upload)         | upload a file on a form                                                      |

--- a/subtree/main.go
+++ b/subtree/main.go
@@ -1,0 +1,99 @@
+// Command subtree is a chromedp example demonstrating how to travel a subtree of the DOM.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/dom"
+	"github.com/chromedp/chromedp"
+)
+
+func main() {
+	// create a test server to serve the page
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<h1 id="title" class="link">
+    <a href="https://test.com/helloworld">
+        content of h1 1
+    </a>
+    <span>hello</span> world
+</h1>
+</body>
+</html>
+`,
+		)
+	}))
+	defer ts.Close()
+
+	// create context
+	ctx, cancel := chromedp.NewContext(context.Background())
+	defer cancel()
+
+	// run task list
+	err := chromedp.Run(ctx, travelSubtree(ts.URL, `title`, chromedp.ByID))
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// travelSubtree illustrates how to ask chromedp to populate a subtree of a node.
+//
+// https://github.com/chromedp/chromedp/issues/632#issuecomment-654213589
+// @mvdan explains why node.Children is almost always empty:
+// Nodes are only obtained from the browser on an on-demand basis.
+// If we always held the entire DOM node tree in memory,
+// our CPU and memory usage in Go would be far higher.
+// And chromedp.FromNode can be used to retrieve the child nodes.
+//
+// Users get confused sometimes (why node.Children is empty while node.ChildNodeCount > 0?).
+// And some users want to travel a subtree of the DOM more easy.
+// So here comes the example.
+func travelSubtree(pageUrl, of string, opts ...chromedp.QueryOption) chromedp.Tasks {
+	var nodes []*cdp.Node
+	return chromedp.Tasks{
+		chromedp.Navigate(pageUrl),
+		chromedp.Nodes(of, &nodes, opts...),
+		// ask chromedp to populate the subtree of a node
+		chromedp.ActionFunc(func(c context.Context) error {
+			// depth -1 for the entire subtree
+			// do your best to limit the size of the subtree
+			return dom.RequestChildNodes(nodes[0].NodeID).WithDepth(-1).Do(c)
+		}),
+		// wait a little while for dom.EventSetChildNodes to be fired and handled
+		chromedp.Sleep(time.Second),
+		chromedp.ActionFunc(func(c context.Context) error {
+			printNodes(nodes, 0)
+			return nil
+		}),
+	}
+}
+
+func printNodes(nodes []*cdp.Node, indent int) {
+	spaces := strings.Repeat(" ", indent)
+	for _, node := range nodes {
+		fmt.Print(spaces)
+		var extra interface{}
+		if node.NodeName == "#text" {
+			extra = node.NodeValue
+		} else {
+			extra = node.Attributes
+		}
+		fmt.Printf("%s: %q\n", node.NodeName, extra)
+		if node.ChildNodeCount > 0 {
+			printNodes(node.Children, indent+4)
+		}
+	}
+}


### PR DESCRIPTION
We understand why `node.Children` is no populated most of the time, but sometimes users get confused. Here are some related issues:

* https://github.com/chromedp/chromedp/issues/332
* https://github.com/chromedp/chromedp/issues/632
* https://github.com/chromedp/chromedp/issues/692
* https://github.com/chromedp/chromedp/issues/761

So here comes the example.

I know that this practice should not be encouraged. So it's okay to refuse this pull request.