### PR TITLE
Adding a proxy authentication example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following examples are currently available:
 | [keys](/keys)                     | send key events to an element                                                |
 | [logic](/logic)                   | more complex logic beyond simple actions                                     |
 | [pdf](/pdf)                       | capture a pdf of a page                                                      |
+| [proxy](/proxy)                   | authenticate a proxy server which requires authentication                    |
 | [remote](/remote)                 | connect to an existing Chrome DevTools instance using a remote WebSocket URL |
 | [screenshot](/screenshot)         | take a screenshot of a specific element and of the entire browser viewport   |
 | [submit](/submit)                 | fill out and submit a form                                                   |

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -1,0 +1,129 @@
+// Command proxy is a chromedp example demonstrating how to authenticate a proxy
+// server which requires authentication.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+
+	"github.com/chromedp/cdproto/fetch"
+	"github.com/chromedp/chromedp"
+)
+
+func main() {
+	// create a simple proxy that requires authentication
+	p := httptest.NewServer(newProxy())
+	defer p.Close()
+
+	// create a web server
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "test")
+	}))
+	defer s.Close()
+
+	opts := append(chromedp.DefaultExecAllocatorOptions[:],
+		// 1) specify the proxy server.
+		// Note that the username/password is not provided here.
+		// Check the link below for the description of the proxy settings:
+		// https://www.chromium.org/developers/design-documents/network-settings
+		chromedp.ProxyServer(p.URL),
+		// By default, Chrome will bypass localhost.
+		// The test server is bound to localhost, so we should add the
+		// following flag to use the proxy for localhost URLs.
+		chromedp.Flag("proxy-bypass-list", "<-loopback>"),
+	)
+	ctx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)
+	defer cancel()
+	// log the protocol messages to understand how it works.
+	ctx, cancel = chromedp.NewContext(ctx, chromedp.WithDebugf(log.Printf))
+	defer cancel()
+
+	// 3) handle the Fetch.AuthRequired event and provide the username/password to the proxy
+	// We will disable the fetch domain and cancel the event handler once the proxy is
+	// authenticated to reduce the overhead. If your project needs the fetch domain to be enabled,
+	// then you should change the code accordingly.
+	lctx, lcancel := context.WithCancel(ctx)
+	chromedp.ListenTarget(lctx, func(ev interface{}) {
+		switch ev := ev.(type) {
+		case *fetch.EventRequestPaused:
+			go func() {
+				_ = chromedp.Run(ctx, fetch.ContinueRequest(ev.RequestID))
+			}()
+		case *fetch.EventAuthRequired:
+			if ev.AuthChallenge.Source == fetch.AuthChallengeSourceProxy {
+				go func() {
+					_ = chromedp.Run(ctx,
+						fetch.ContinueWithAuth(ev.RequestID, &fetch.AuthChallengeResponse{
+							Response: fetch.AuthChallengeResponseResponseProvideCredentials,
+							Username: "u",
+							Password: "p",
+						}),
+						// Chrome will remember the credential for the current instance,
+						// so we can disable the fetch domain once credential is provided.
+						// Please file an issue if Chrome does not work in this way.
+						fetch.Disable(),
+					)
+					// and cancel the event handler too.
+					lcancel()
+				}()
+			}
+		}
+	})
+
+	if err := chromedp.Run(ctx,
+		// 2) enable the fetch domain to handle the Fetch.AuthRequired event
+		fetch.Enable().WithHandleAuthRequests(true),
+		chromedp.Navigate(s.URL),
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	// to show that further requests (even in new tabs) are authenticated.
+	tctx, cancel := chromedp.NewContext(ctx)
+	defer cancel()
+	if err := chromedp.Run(tctx,
+		chromedp.Navigate(s.URL+"/tab"),
+	); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// newProxy creates a proxy that requires authentication.
+func newProxy() *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{
+		Director: func(r *http.Request) {
+			if dump, err := httputil.DumpRequest(r, true); err == nil {
+				log.Printf("%s", dump)
+			}
+			// hardcode username/password "u:p" (base64 encoded: dTpw ) to make it simple
+			if auth := r.Header.Get("Proxy-Authorization"); auth != "Basic dTpw" {
+				r.Header.Set("X-Failed", "407")
+			}
+		},
+		Transport: &transport{http.DefaultTransport},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			if err.Error() == "407" {
+				log.Println("proxy: not authorized")
+				w.Header().Add("Proxy-Authenticate", `Basic realm="Proxy Authorization"`)
+				w.WriteHeader(407)
+			} else {
+				w.WriteHeader(http.StatusBadGateway)
+			}
+		},
+	}
+}
+
+type transport struct {
+	http.RoundTripper
+}
+
+func (t *transport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if h := r.Header.Get("X-Failed"); h != "" {
+		return nil, fmt.Errorf(h)
+	}
+	return t.RoundTripper.RoundTrip(r)
+}


### PR DESCRIPTION
Relevant issues:

* https://github.com/chromedp/chromedp/issues/190
* https://github.com/chromedp/chromedp/issues/645

The example handles the [Fetch.authRequired](https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#event-authRequired) event to provide the username/password to the browser. This should be the expected way to do it. Please note that using [Network.setExtraHTTPHeaders](https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setExtraHTTPHeaders) to provide the `Proxy-Authorization` header does not work (got `net::ERR_INVALID_ARGUMENT`. See the  log below).

```
2021/06/01 18:16:43 -> {"id":14,"sessionId":"190A3BDEAD30C3F4948AA592F58378D9","method":"Network.setExtraHTTPHeaders","params":{"headers":{"Proxy-Authorization":"Basic dTpw"}}}
2021/06/01 18:16:43 <- {"id":14,"result":{},"sessionId":"190A3BDEAD30C3F4948AA592F58378D9"}
2021/06/01 18:16:43 -> {"id":15,"sessionId":"190A3BDEAD30C3F4948AA592F58378D9","method":"Page.navigate","params":{"url":"http://192.168.3.201:41745"}}
2021/06/01 18:16:43 <- {"method":"Network.requestWillBeSent","params":{"requestId":"6E274E03E3474E8DE7C59A837C24B1BD","loaderId":"6E274E03E3474E8DE7C59A837C24B1BD","documentURL":"http://192.168.3.201:41745/","request":{"url":"http://192.168.3.201:41745/","method":"GET","headers":{"Upgrade-Insecure-Requests":"1","User-Agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/91.0.4472.77 Safari/537.36","Proxy-Authorization":"Basic dTpw"},"mixedContentType":"none","initialPriority":"VeryHigh","referrerPolicy":"strict-origin-when-cross-origin"},"timestamp":606087.582753,"wallTime":1622542603.942344,"initiator":{"type":"other"},"type":"Document","frameId":"FF320EDC0EB316179D775263C2061F12","hasUserGesture":false},"sessionId":"190A3BDEAD30C3F4948AA592F58378D9"}
2021/06/01 18:16:43 <- {"method":"Network.loadingFailed","params":{"requestId":"6E274E03E3474E8DE7C59A837C24B1BD","timestamp":606087.583328,"type":"Document","errorText":"net::ERR_INVALID_ARGUMENT","canceled":false},"sessionId":"190A3BDEAD30C3F4948AA592F58378D9"}
2021/06/01 18:16:43 <- {"id":15,"result":{"frameId":"FF320EDC0EB316179D775263C2061F12","loaderId":"6E274E03E3474E8DE7C59A837C24B1BD","errorText":"net::ERR_INVALID_ARGUMENT"},"sessionId":"190A3BDEAD30C3F4948AA592F58378D9"}
```

#### Why not implement this feature in `chromedp`?

The authentication process is:

1. Enable the `Fetch` domain;
2. Handle  the  `Fetch.authRequired` event to provide the username/password;
3. Disable the `Fetch` domain and remove the event handler.

If the user wants to handle the events in the `Fetch` domain too, there is a conflict. Since `chromedp` does not wrap and hide the CDP events (and I think this is a pro), there is not a good way to coordinate the two event handlers.

On the other side, the use cases that involve a proxy required authentication should be rare. An example should be good enough to serve those use cases.

And it will keep `chromedp` simple too.