### PR TITLE
Change selector from body > div > footer to just body > footer on click2 example

### DIFF
--- a/click2/main.go
+++ b/click2/main.go
@@ -27,7 +27,7 @@ func main() {
 	err := chromedp.Run(ctx,
 		chromedp.Navigate(`https://pkg.go.dev/time`),
 		// wait for footer element is visible (ie, page is loaded)
-		chromedp.WaitVisible(`body > div > footer`),
+		chromedp.WaitVisible(`body > footer`),
 		// find and click "Example" link
 		chromedp.Click(`#example-After`, chromedp.NodeVisible),
 		// retrieve the text of the textarea


### PR DESCRIPTION
Using `body > div > footer` selector doesn't work, I think they updated the website. `body > footer` will work just fine at least for now.