### PR TITLE
Remove deprecated ioutil package

### DIFF
--- a/download_image/main.go
+++ b/download_image/main.go
@@ -9,8 +9,8 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
+	"os"
 	"time"
 
 	"github.com/chromedp/cdproto/network"
@@ -78,7 +78,7 @@ func main() {
 
 	// write the file to disk - since we hold the bytes we dictate the name and
 	// location
-	if err := ioutil.WriteFile("download.png", buf, 0644); err != nil {
+	if err := os.WriteFile("download.png", buf, 0644); err != nil {
 		log.Fatal(err)
 	}
 	log.Print("wrote download.png")

--- a/emulate/main.go
+++ b/emulate/main.go
@@ -4,8 +4,8 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/device"
@@ -35,10 +35,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile("screenshot1.png", b1, 0o644); err != nil {
+	if err := os.WriteFile("screenshot1.png", b1, 0o644); err != nil {
 		log.Fatal(err)
 	}
-	if err := ioutil.WriteFile("screenshot2.png", b2, 0o644); err != nil {
+	if err := os.WriteFile("screenshot2.png", b2, 0o644); err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("wrote screenshot1.png and screenshot2.png")

--- a/pdf/main.go
+++ b/pdf/main.go
@@ -5,8 +5,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
@@ -23,7 +23,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile("sample.pdf", buf, 0o644); err != nil {
+	if err := os.WriteFile("sample.pdf", buf, 0o644); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println("wrote sample.pdf")

--- a/screenshot/main.go
+++ b/screenshot/main.go
@@ -4,8 +4,8 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/chromedp/chromedp"
 )
@@ -23,7 +23,7 @@ func main() {
 	if err := chromedp.Run(ctx, elementScreenshot(`https://pkg.go.dev/`, `img.Homepage-logo`, &buf)); err != nil {
 		log.Fatal(err)
 	}
-	if err := ioutil.WriteFile("elementScreenshot.png", buf, 0o644); err != nil {
+	if err := os.WriteFile("elementScreenshot.png", buf, 0o644); err != nil {
 		log.Fatal(err)
 	}
 
@@ -31,7 +31,7 @@ func main() {
 	if err := chromedp.Run(ctx, fullScreenshot(`https://brank.as/`, 90, &buf)); err != nil {
 		log.Fatal(err)
 	}
-	if err := ioutil.WriteFile("fullScreenshot.png", buf, 0o644); err != nil {
+	if err := os.WriteFile("fullScreenshot.png", buf, 0o644); err != nil {
 		log.Fatal(err)
 	}
 

--- a/upload/main.go
+++ b/upload/main.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -73,7 +73,7 @@ func uploadServer(addr string, result chan int) error {
 		}
 		defer f.Close()
 
-		buf, err := ioutil.ReadAll(f)
+		buf, err := io.ReadAll(f)
 		if err != nil {
 			http.Error(res, err.Error(), http.StatusBadRequest)
 			return


### PR DESCRIPTION
 This PR replaces `ioutil`package usages with `io` or `os` because `ioutil` is [deprecated](https://pkg.go.dev/io/ioutil).

From the doc:
```
As of Go 1.16, the same functionality is now provided by package io or package os
```