### PR TITLE
Fix typo and grammar issues in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ which tend to require internet access or external components.
 
 Please note that when the `chromedp` package is being rewritten, these examples
 may break. Additionally, since these examples are written for specific websites,
-there is a good chance that the current selectors, etc break after the website
+there is a good chance that the current selectors, etc. break after the website
 they are written against changes.
 
 While every effort is made to ensure that these examples are kept up-to-date,

--- a/download_file/main.go
+++ b/download_file/main.go
@@ -32,7 +32,7 @@ func main() {
 	ctx, cancel = context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	// set up a channel so we can block later while we monitor the download
+	// set up a channel, so we can block later while we monitor the download
 	// progress
 	done := make(chan string, 1)
 	// set up a listener to watch the download events and close the channel
@@ -59,7 +59,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// download the zip of the chromedp/examples repo from github. we use a
+	// download the zip of the chromedp/examples repo from GitHub. We use a
 	// link click method here but this could also be done with a
 	// chromedp.Navigate task which points directly at the file we want to
 	// download, as long as you run browser.SetDownloadBehavior first

--- a/download_image/main.go
+++ b/download_image/main.go
@@ -29,11 +29,11 @@ func main() {
 	ctx, cancel = context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
-	// set up a channel so we can block later while we monitor the download
+	// set up a channel, so we can block later while we monitor the download
 	// progress
 	done := make(chan bool)
 
-	// set the download url as the chromedp github user avatar
+	// set the download url as the chromedp GitHub user avatar
 	urlstr := "https://avatars.githubusercontent.com/u/33149672"
 
 	// this will be used to capture the request id for matching network events


### PR DESCRIPTION
This PR fixes the following:
- github -> GitHub
- comma before "so"
- "etc" with period