### PR TITLE
examples: Add context deadline error handling

### DIFF
--- a/download_file/main.go
+++ b/download_file/main.go
@@ -86,10 +86,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// This will block until the chromedp listener closes the channel
-	guid := <-done
-
-	// We can predict the exact file location and name here because of how we
-	// configured SetDownloadBehavior and WithDownloadPath
-	log.Printf("wrote %s", filepath.Join(wd, guid))
+	select {
+	case <-ctx.Done(): // Webiste unresponsive or could not download file within the specified timeout. Return error to unblock execution.
+		log.Fatalf("context timed out: %v", ctx.Err())
+	case guid := <-done: // This will block until the chromedp listener closes the channel
+		// We can predict the exact file location and name here because of how we
+		// configured SetDownloadBehavior and WithDownloadPath
+		log.Printf("wrote %s", filepath.Join(wd, guid))
+	}
 }


### PR DESCRIPTION
On a project that I recently worked on I had an issue where sometimes the site I was scraping became unresponsive while downloading files.

This PR adds a select to handle the context deadline exceeded and safely stop the execution of the program.

We scrape certain websites on a daily basis via a reflex event queue Finite state machine. 
The file download section I edited in this PR "blocked" the queue and completely stopped processing events.
I had to manually restart our instance each time to get the downloads to finish. This change I implemented sorted out my issue and will hopefully help anyone else in the future.
